### PR TITLE
Fix upload directory path

### DIFF
--- a/src/Badger/Bundle/GameBundle/Entity/Badge.php
+++ b/src/Badger/Bundle/GameBundle/Entity/Badge.php
@@ -208,7 +208,7 @@ class Badge implements BadgeInterface, JsonSerializable
      */
     protected function getUploadRootDir()
     {
-        return __DIR__ . '/../../../../web/' . $this->getUploadDir();
+        return __DIR__ . '/../../../../../web/' . $this->getUploadDir();
     }
 
     /**


### PR DESCRIPTION
The function getUploadRootDir does not return the good path. 
With the current code, the images are uploaded in src/web/upload/game. This is fixing it.

Maybe this is an artifact of the folder architecture change for S3 ?