### PR TITLE
Fix BC of Symfony 3.3 for PHP7

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -6,7 +6,10 @@ use Symfony\Component\HttpFoundation\Request;
  * @var Composer\Autoload\ClassLoader
  */
 $loader = require __DIR__.'/../app/autoload.php';
-include_once __DIR__.'/../app/bootstrap.php.cache';
+
+if (PHP_VERSION_ID < 70000) {
+    include_once __DIR__.'/../var/bootstrap.php.cache';
+}
 
 // Enable APC for autoloading to improve performance.
 // You should change the ApcClassLoader first argument to a unique prefix
@@ -21,7 +24,10 @@ $apcLoader->register(true);
 //require_once __DIR__.'/../app/AppCache.php';
 
 $kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
+
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
 //$kernel = new AppCache($kernel);
 
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -25,7 +25,11 @@ $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
+
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
+
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
Hello,

fixed a warning when Symfony 3 is >= 3.3, see the related contribution on Symfony project => https://github.com/symfony/symfony-standard/commit/9b2e12f6d5543f7d441e7d91ae57e16644aada53#diff-64a0fd926147fcc158821dcb6f1b4d11

Mickaël