### PR TITLE
Disable display of social logins connection methods if needed

### DIFF
--- a/app/Resources/HWIOAuthBundle/views/Connect/login.html.twig
+++ b/app/Resources/HWIOAuthBundle/views/Connect/login.html.twig
@@ -12,16 +12,20 @@
         <div class="ui raised segment" style="padding: 25px;">
             <h3 class="ui header" style="font-weight: normal;">Sign in to Badger</h3>
             <div class="ui extra content" style="margin: 50px 0;">
+                {% if(google_client_activated) %}
                 <p>
                     <a class="ui labeled icon google plus large button" href="{{ path('hwi_oauth_service_redirect', {'service': 'google' }) }}">
                         <i class="google icon"></i> Sign in with Google
                     </a>
                 </p>
+                {% endif %}
+                {% if(github_client_activated) %}
                 <p>
                     <a class="ui labeled icon large button" href="{{ path('github_connect') }}">
                         <i class="icon github"></i> Sign in with GitHub
                     </a>
                 </p>
+                {% endif %}
             </div>
         </div>
         <p style="color: #B9B9B9;">version {{ app_version }}</p>

--- a/app/Resources/HWIOAuthBundle/views/base.html.twig
+++ b/app/Resources/HWIOAuthBundle/views/base.html.twig
@@ -56,8 +56,13 @@
 
                         <div class="content-divider text-muted form-group"><span>sign in with</span></div>
                         <ul class="list-inline form-group list-inline-condensed text-center">
-                            <li><a href="{{ path('hwi_oauth_service_redirect', {'service': 'google' }) }}" class="btn border-danger text-danger-700 btn-flat btn-icon btn-rounded"><i class="icon-google"></i></a></li>
-                            <li><a href="{{ path('github_connect') }}" class="btn border-slate-600 text-slate-600 btn-flat btn-icon btn-rounded"><i class="icon-github"></i></a></li>
+
+                            {% if(google_client_activated) %}
+                                <li><a href="{{ path('hwi_oauth_service_redirect', {'service': 'google' }) }}" class="btn border-danger text-danger-700 btn-flat btn-icon btn-rounded"><i class="icon-google"></i></a></li>
+                            {% endif %}
+                            {% if(github_client_activated) %}
+                                <li><a href="{{ path('github_connect') }}" class="btn border-slate-600 text-slate-600 btn-flat btn-icon btn-rounded"><i class="icon-github"></i></a></li>
+                            {% endif %}
                         </ul>
                     </div>
                 </form>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -41,6 +41,8 @@ twig:
     strict_variables: "%kernel.debug%"
     globals:
         app_version: "%version%"
+        google_client_activated: %google_client_activated%
+        github_client_activated: %github_client_activated%
     form_themes:
         - 'GameBundle:Form:game-fields.html.twig'
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -19,12 +19,14 @@ parameters:
     secret:            ThisTokenIsNotSoSecretChangeIt
 
     # For oAuth Github authentication
-    github_client_id:     YOUR_GITHUB_CLIENT_ID
-    github_client_secret: YOUR_GITHUB_CLIENT_SECRET
+    github_client_id:           YOUR_GITHUB_CLIENT_ID
+    github_client_secret:       YOUR_GITHUB_CLIENT_SECRET
+    github_client_activated:    true
 
     # For oAuth Google authentication
-    google_client_id:     YOUR_GOOGLE_CLIENT_ID
-    google_client_secret: YOUR_GOOGLE_CLIENT_SECRET
+    google_client_id:           YOUR_GOOGLE_CLIENT_ID
+    google_client_secret:       YOUR_GOOGLE_CLIENT_SECRET
+    google_client_activated:    true
 
     # Slack webhook url to send message in Slack channels
     slack_webhook_url: YOU_SLACK_WEBHOOK_URL


### PR DESCRIPTION
I put the config as global twig variables because it otherwise means that we have to rewrite all the vendor controller for the connection.
It is not disabling the paths.